### PR TITLE
fix(ios): point liveness SDK at Webeleven fork to stop VideoChunker append crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.2
+
+* iOS: fix fatal `NSInternalInconsistencyException` ("Must start a session ... before
+  appending pixel buffers") crash originating in the Amplify liveness SDK's
+  `VideoChunker`. The iOS dependency now points at the Webeleven fork of
+  `amplify-ui-swift-liveness` (tag `1.4.4-webeleven.1`), which serializes the
+  `AVAssetWriter` start/finish/consume lifecycle to close an append-after-finish data
+  race. Upstream 1.4.4 is still affected. Revert to the upstream package once the fix
+  lands there.
+
 ## 0.0.1
 
 * TODO: Describe initial release.

--- a/ios/rekognition_face_liveness/Package.swift
+++ b/ios/rekognition_face_liveness/Package.swift
@@ -16,7 +16,12 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/aws-amplify/amplify-swift", from: "2.3.1"),
-        .package(url: "https://github.com/aws-amplify/amplify-ui-swift-liveness", from: "1.3.4")
+        // Webeleven fork of amplify-ui-swift-liveness, pinned to a patched 1.4.4 that fixes
+        // the VideoChunker AVAssetWriter append-after-finish data race (crash:
+        // NSInternalInconsistencyException "Must start a session ... before appending pixel
+        // buffers"). The bug is still present in upstream 1.4.4. Drop this fork and return to
+        // the upstream package once the fix lands upstream.
+        .package(url: "https://github.com/Webeleven/amplify-ui-swift-liveness", exact: "1.4.4-webeleven.1")
     ],
     targets: [
         .target(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rekognition_face_liveness
 description: "A new Flutter plugin project."
-version: 0.0.1
+version: 0.0.2
 homepage:
 
 environment:


### PR DESCRIPTION
## Problema

Crash fatal em produção (Sentry **ABA-CENTRAL-APP-58**, iPhone 16 / iOS 26), no fluxo de liveness:

```
NSInternalInconsistencyException
-[AVAssetWriterInputPixelBufferAdaptor appendPixelBuffer:withPresentationTime:]
Must start a session ... before appending pixel buffers
```

A exceção vem de `VideoChunker.swift:71` do SDK `amplify-ui-swift-liveness` — **não** do nosso código (nosso plugin não tem AVFoundation).

## Causa raiz (upstream)

`VideoChunker.consume(_:)` roda na worker queue da câmera enquanto `start()`/`finish()` rodam na thread do view model, sem sincronização → um frame pode chamar `append` depois que a sessão de escrita foi encerrada. Presente até a 1.4.4 (mais recente). Issues upstream #68/#81 fechadas contra outra corrida (`AVCaptureSession`, corrigida na 1.2.2); o append race nunca foi tratado.

## Fix

Repontar a dependência SPM para o fork **[Webeleven/amplify-ui-swift-liveness](https://github.com/Webeleven/amplify-ui-swift-liveness)** `@ 1.4.4-webeleven.1` ([PR #1](https://github.com/Webeleven/amplify-ui-swift-liveness/pull/1)), que serializa `start`/`finish`/`consume` numa serial queue e adiciona guard `assetWriter.status == .writing` antes do `append`.

- Único ponto a mexer: `ios/rekognition_face_liveness/Package.swift` (o `.podspec` só depende de `Flutter`; o SDK vem 100% via SPM).
- Bump 0.0.1 → 0.0.2, CHANGELOG atualizado.

Reverter pro pacote upstream quando a AWS corrigir.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swapping the native liveness SDK to a third-party fork changes critical camera/recording behavior on iOS; scope is small but impact on the liveness path is high until upstream ships the same fix.
> 
> **Overview**
> **Release 0.0.2** addresses a production iOS crash in face liveness (`NSInternalInconsistencyException` when appending pixel buffers after the `AVAssetWriter` session has ended). The failure comes from upstream **`amplify-ui-swift-liveness`** `VideoChunker`, not plugin code.
> 
> The iOS SPM dependency in **`Package.swift`** is switched from the official **`amplify-ui-swift-liveness`** (was `from: "1.3.4"`) to **`Webeleven/amplify-ui-swift-liveness`** pinned at **`1.4.4-webeleven.1`**, which serializes writer start/finish/consume and guards append while writing. **`pubspec.yaml`** is bumped to **0.0.2** and **`CHANGELOG.md`** documents the fork and intent to revert when upstream fixes land.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c587156ecc4fedfcda2d240d0eaf5b76f02ac3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Versão do pacote incrementada para 0.0.2
  * Dependência externa atualizada com versão específica pinada

<!-- end of auto-generated comment: release notes by coderabbit.ai -->