### PR TITLE
chore(ios): bump to v0.0.3 — pin immutable SDK tag 1.4.4-webeleven.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.3
+
+* iOS: bump the liveness SDK fork to `1.4.4-webeleven.2`, which adds two PR-review
+  hardenings on top of 0.0.2: deliver the final single frame on the main queue (outside the
+  serial lock) and only call `finishWriting` when the writer status is `.writing`. Uses a
+  fresh immutable tag (the previous `1.4.4-webeleven.1` tag had been moved, which broke SPM
+  resolution).
+
 ## 0.0.2
 
 * iOS: fix fatal `NSInternalInconsistencyException` ("Must start a session ... before

--- a/ios/rekognition_face_liveness/Package.swift
+++ b/ios/rekognition_face_liveness/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         // NSInternalInconsistencyException "Must start a session ... before appending pixel
         // buffers"). The bug is still present in upstream 1.4.4. Drop this fork and return to
         // the upstream package once the fix lands upstream.
-        .package(url: "https://github.com/Webeleven/amplify-ui-swift-liveness", exact: "1.4.4-webeleven.1")
+        .package(url: "https://github.com/Webeleven/amplify-ui-swift-liveness", exact: "1.4.4-webeleven.2")
     ],
     targets: [
         .target(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rekognition_face_liveness
 description: "A new Flutter plugin project."
-version: 0.0.2
+version: 0.0.3
 homepage:
 
 environment:


### PR DESCRIPTION
Follow-up to #3 (which merged at v0.0.2 pinning `1.4.4-webeleven.1`).

The `-webeleven.1` tag was later **moved** to fold in PR-review hardenings, and SwiftPM rejects moved tags (`does not match previously recorded value`) — which breaks CI, since Codemagic has no SwiftPM reset step. This bumps `Package.swift` to the fresh **immutable** tag `1.4.4-webeleven.2` (same hardened commit `cc1b961`) so `main` no longer references the moved tag.

- `Package.swift`: `exact: 1.4.4-webeleven.1` → `1.4.4-webeleven.2`
- version 0.0.2 → 0.0.3 + CHANGELOG

App PR Webeleven/aba-central-app#333 already pins this plugin commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and SPM pin only in this repo; iOS behavior changes live in the forked SDK dependency, with small threading/writer-status hardenings.
> 
> **Overview**
> Releases **v0.0.3** and repins the iOS **Webeleven** `amplify-ui-swift-liveness` fork from `1.4.4-webeleven.1` to **`1.4.4-webeleven.2`** in `Package.swift`, because the earlier tag was moved and SwiftPM then fails to resolve dependencies in CI.
> 
> The new tag is documented as **immutable** and carries two extra **VideoChunker** hardenings: final single-frame delivery on the main queue (outside the serial lock) and calling `finishWriting` only when the writer is `.writing`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5c320a98a39bcf327d0cd5c9b797b397892c1a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Atualizada a dependência iOS amplify-ui-swift-liveness para a versão mais recente disponível, melhorando significativamente a compatibilidade geral do sistema, segurança robusta e desempenho aprimorado da aplicação completa.
* Atualizada a versão do pacote Flutter/Dart para 0.0.3, com melhorias internas significativas, otimizações de performance aplicadas, correções críticas de estabilidade, refinamentos diversos e ajustes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->