### PR TITLE
fix(ios): stable error codes per cause; cancel event subscription on dispose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.0.4
+
+* iOS: map `accessDenied` and `cameraPermissionDenied` to the same stable codes
+  Android already emits, and resolve a stable member name for every other
+  `FaceLivenessDetectionError` in the fallback (`error:<name>:<message>`, using the
+  SDK's fixed English `message` instead of the locale-dependent
+  `localizedDescription`). Previously every unmapped iOS error stringified to the
+  same struct type name, so consumers (e.g. Sentry grouping) could not tell a
+  credentials outage from a benign timeout.
+* Dart: cancel the `face_liveness_event` subscription in `dispose`. The previous
+  code never cancelled, so the last detector's callbacks stayed subscribed to the
+  broadcast channel for the app's lifetime and late native events (teardown
+  errors) still reached widgets that were already gone.
+
 ## 0.0.3
 
 * iOS: bump the liveness SDK fork to `1.4.4-webeleven.2`, which adds two PR-review

--- a/ios/rekognition_face_liveness/Sources/rekognition_face_liveness/FaceLivenessView.swift
+++ b/ios/rekognition_face_liveness/Sources/rekognition_face_liveness/FaceLivenessView.swift
@@ -115,10 +115,18 @@ struct NativeView: View {
                     case .sessionNotFound:
                         handler.onError(code: "sessionNotFound")
                         return
+                    case .accessDenied:
+                        handler.onError(code: "accessDenied")
+                        return
+                    case .cameraPermissionDenied:
+                        handler.onError(code: "cameraPermissionDenied")
+                        return
                     default:
-                        let errorType = String(describing: type(of: error))
-                        let errorMsg = error.localizedDescription
-                        handler.onError(code: "error:\(errorType):\(errorMsg)")
+                        // `error.message` is the SDK's fixed English text — unlike
+                        // localizedDescription, it doesn't vary with device locale.
+                        handler.onError(
+                            code: "error:\(stableErrorName(for: error)):\(error.message)"
+                        )
                         return
                     }
                 default:
@@ -127,4 +135,29 @@ struct NativeView: View {
             }
         )
     }
+}
+
+/// Stable name for a `FaceLivenessDetectionError`, mirroring the per-class
+/// granularity Android gets from exception type names. The SDK models every
+/// error as the same Equatable struct, so `type(of:)` names them all
+/// identically; matching against the SDK's static members recovers the case
+/// name so consumers can distinguish causes (Sentry grouping, alerting).
+private func stableErrorName(for error: FaceLivenessDetectionError) -> String {
+    let knownErrors: [(FaceLivenessDetectionError, String)] = [
+        (.unknown, "unknown"),
+        (.faceInOvalMatchExceededTimeLimitError, "faceInOvalMatchExceededTimeLimit"),
+        (.socketClosed, "socketClosed"),
+        (.countdownFaceTooClose, "countdownFaceTooClose"),
+        (.countdownMultipleFaces, "countdownMultipleFaces"),
+        (.countdownNoFace, "countdownNoFace"),
+        (.invalidRegion, "invalidRegion"),
+        (.validation, "validation"),
+        (.internalServer, "internalServer"),
+        (.throttling, "throttling"),
+        (.serviceQuotaExceeded, "serviceQuotaExceeded"),
+        (.serviceUnavailable, "serviceUnavailable"),
+        (.invalidSignature, "invalidSignature"),
+        (.cameraNotAvailable, "cameraNotAvailable"),
+    ]
+    return knownErrors.first { $0.0 == error }?.1 ?? "FaceLivenessDetectionError"
 }

--- a/lib/face_liveness_detector.dart
+++ b/lib/face_liveness_detector.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -25,17 +26,28 @@ class FaceLivenessDetector extends StatefulWidget {
 
 class _FaceLivenessDetectorState extends State<FaceLivenessDetector> {
   final _eventChannel = EventChannel('face_liveness_event');
+  StreamSubscription<dynamic>? _eventSubscription;
 
   @override
   void initState() {
     super.initState();
-    _eventChannel.receiveBroadcastStream().listen((event) {
+    _eventSubscription = _eventChannel.receiveBroadcastStream().listen((event) {
       if (event == 'complete') {
         widget.onComplete?.call();
       } else {
         widget.onError?.call(event);
       }
     });
+  }
+
+  @override
+  void dispose() {
+    // Without cancelling, the callbacks of the last detector stay subscribed
+    // to the broadcast channel for the app's lifetime, so late native events
+    // (e.g. teardown errors) still reach a widget that is already gone.
+    _eventSubscription?.cancel();
+    _eventSubscription = null;
+    super.dispose();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: rekognition_face_liveness
 description: "A new Flutter plugin project."
-version: 0.0.3
+version: 0.0.4
 homepage:
 
 environment:


### PR DESCRIPTION
## Summary

Two fixes flagged by the red-team review of Webeleven/aba-central-app#345 (TODOS.md "Liveness error-handling follow-ups" items 1 and 2):

**iOS — stable error codes per cause.** Every `FaceLivenessDetectionError` is the same Equatable struct, so the fallback's `type(of:)` named all unmapped failures identically (`error:FaceLivenessDetectionError:<localized msg>`). Consumers couldn't distinguish an `accessDenied` credentials outage from a benign timeout — on the app side this collapsed every unmapped iOS error into one Sentry issue, defeating the `session.liveness_error_code` grouping/alerting added in app PR #345. Now:
- `accessDenied` / `cameraPermissionDenied` map to the same stable codes Android already emits (the app already handles both: localized message + OK→Settings shortcut).
- The fallback resolves the static member name via Equatable lookup (`error:socketClosed:…`, `error:invalidSignature:…`, etc.), mirroring the per-class granularity Android gets from exception type names, and uses the SDK's fixed English `message` instead of the locale-dependent `localizedDescription`.

**Dart — cancel the event subscription on dispose.** `_FaceLivenessDetectorState` never cancelled its `face_liveness_event` subscription, so the last detector's callbacks stayed subscribed to the broadcast channel for the app's lifetime — late native teardown events kept reaching widgets that were already gone (phantom Sentry errors / spurious dialogs during route exit). `dispose()` now cancels it.

Version 0.0.3 → 0.0.4 (CHANGELOG updated).

## Compatibility

No app-side change required: the new codes are the vocabulary the app already handles for Android; unmapped codes keep the `error:<name>:<message>` shape the app's fallback parses. SDK pin unchanged (`1.4.4-webeleven.2`).

## Evidence

- `flutter analyze` on the package: clean (2 pre-existing infos in `example/`).
- App compile check: `flutter build ios --no-codesign` on aba-central-app `development` with the pin bumped to this commit — result posted in the companion app PR.
- Runtime check needs a physical device (AWS liveness streaming doesn't run on simulator): revoke camera permission mid-flow → app shows the camera message with Settings shortcut and Sentry tags `session.liveness_error_code=cameraPermissionDenied`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted error-code mapping and a subscription lifecycle fix in the liveness plugin; no auth or API contract changes beyond more precise error strings.
> 
> **Overview**
> **iOS** now emits **stable, Android-aligned error codes** so apps can group and alert on liveness failures (e.g. Sentry). `accessDenied` and `cameraPermissionDenied` are mapped explicitly; other `FaceLivenessDetectionError` cases use a new `stableErrorName(for:)` lookup instead of `type(of:)`, which previously collapsed every failure to the same struct name. Fallback payloads use the SDK’s fixed English `message` rather than locale-dependent `localizedDescription`.
> 
> **Dart** cancels the `face_liveness_event` `StreamSubscription` in `dispose()`, so the last detector no longer keeps listening on the broadcast channel after the widget is removed—avoiding late native teardown events hitting disposed widgets.
> 
> Release **0.0.4** (`pubspec.yaml`, `CHANGELOG.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaaf38046067ac8ab93f892de3bd3eae1fc7eb3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorado o tratamento de erros de permissão de câmera e acesso, com mensagens de erro mais estáveis e precisas.
  * Corrigida vazamento de memória que mantinha callbacks ativos após o widget ser removido.

* **Chores**
  * Versão incrementada para 0.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->